### PR TITLE
Only count failed changes when reporting summary

### DIFF
--- a/src/format-message.ts
+++ b/src/format-message.ts
@@ -49,7 +49,8 @@ const getSummary = (
       checkSchemaResult?.diffToPrevious.severity === 'WARNING' ||
       checkSchemaResult?.diffToPrevious.severity === 'FAILURE'
     ) {
-      summary += `❌ Found **${checkSchemaResult?.diffToPrevious.changes.length} breaking changes**\n\n`;
+      const issueCount = checkSchemaResult?.diffToPrevious.changes.filter((c) => c.severity === 'FAILURE' || c.severity === 'WARNING').length;
+      summary += `❌ Found **${issueCount} breaking changes**\n\n`;
 
       setFailed('Breaking changes found');
     }


### PR DESCRIPTION
**Problem**
When a schema change causes a failure, we then go in and get the number of changes to report as the total number of changes that are broken, however all changes are not breaking changes.

![image](https://user-images.githubusercontent.com/542149/188974710-62b69d71-8d58-41b1-a668-7cb9c7bbe1ea.png)

![image](https://user-images.githubusercontent.com/542149/188974647-ea8c0576-4b76-472d-97c9-19b432cc7748.png)


**Solution**
Filter the change list to only those that are broken when generating the total count